### PR TITLE
[FEAT] 메인 대시보드 컴포넌트 구현 (#8)

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,9 +1,25 @@
-export default function DashboardPage() {
+// src/app/dashboard/page.tsx
+"use client";
+
+import StatusBar from "../../components/dashboard/StatusBar";
+import AIPanel from "../../components/dashboard/AIPanel";
+import ActivityList from "../../components/dashboard/ActivityList";
+
+export default function Dashboard() {
   return (
-    <div className="min-h-screen bg-gray-900 text-white">
-      <div className="flex items-center justify-center h-screen">
-        <h1 className="text-4xl font-bold">🚀 NEXUS DASHBOARD</h1>
-        <p className="text-gray-400 mt-4">메인 대시보드는 나중에 구현예정</p>
+    <div className="min-h-screen bg-gray-950 p-6">
+      <div className="max-w-7xl mx-auto">
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+          <div className="lg:col-span-3">
+            <StatusBar />
+          </div>
+          <div className="lg:col-span-6">
+            <AIPanel />
+          </div>
+          <div className="lg:col-span-3">
+            <ActivityList />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/dashboard/AIPanel.tsx
+++ b/src/components/dashboard/AIPanel.tsx
@@ -1,0 +1,39 @@
+// src/components/dashboard/AIPanel.tsx
+"use client";
+
+export default function AIPanel() {
+  return (
+    <div className="space-y-4">
+      {/* 헤더 */}
+      <div className="flex items-center space-x-2">
+        <div className="w-2 h-2 bg-blue-400 rounded-full animate-pulse"></div>
+        <h2 className="text-lg font-light text-blue-300 tracking-wider">
+          AI ASSISTANT
+        </h2>
+      </div>
+
+      {/* 메인 AI 패널 */}
+      <div className="bg-gray-900/50 backdrop-blur-lg border border-blue-500/20 rounded-lg p-8">
+        <div className="text-center space-y-6">
+          {/* 제목 */}
+          <div>
+            <h3 className="text-2xl font-light text-blue-300 mb-2">
+              E.D.I.T.H AI
+            </h3>
+            <p className="text-gray-400 text-sm">
+              AI 기능은 추후 업데이트 예정입니다
+            </p>
+          </div>
+
+          {/* 상태 표시 */}
+          <div className="flex items-center justify-center space-x-2">
+            <div className="w-2 h-2 bg-yellow-400 rounded-full animate-pulse"></div>
+            <span className="text-xs text-yellow-400 font-mono">
+              DEVELOPMENT
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/ActivityList.tsx
+++ b/src/components/dashboard/ActivityList.tsx
@@ -1,0 +1,303 @@
+// src/components/dashboard/ActivityList.tsx
+"use client";
+
+import { useState, useEffect } from "react";
+
+// ==================== 타입 정의 ====================
+interface CalendarDate {
+  year: number;
+  month: number;
+  today: number;
+  firstDay: number;
+  lastDate: number;
+}
+
+// ==================== 상수 ====================
+const START_DATE = new Date("2025-06-01"); // E.D.I.T.H 시작일
+
+const MONTH_NAMES = [
+  "1월",
+  "2월",
+  "3월",
+  "4월",
+  "5월",
+  "6월",
+  "7월",
+  "8월",
+  "9월",
+  "10월",
+  "11월",
+  "12월",
+] as const;
+
+const WEEK_DAYS = ["일", "월", "화", "수", "목", "금", "토"] as const;
+
+const ANIMATION_CONFIG = {
+  duration: 30,
+  interval: 50,
+  loadingDelay: 2000,
+} as const;
+
+// ==================== 유틸리티 함수 ====================
+const calculateDaysDiff = (startDate: Date, endDate: Date): number => {
+  const diffTime = Math.abs(endDate.getTime() - startDate.getTime());
+  return Math.floor(diffTime / (1000 * 60 * 60 * 24));
+};
+
+const getCalendarData = (currentDate: Date): CalendarDate => ({
+  year: currentDate.getFullYear(),
+  month: currentDate.getMonth(),
+  today: new Date().getDate(),
+  firstDay: new Date(
+    currentDate.getFullYear(),
+    currentDate.getMonth(),
+    1,
+  ).getDay(),
+  lastDate: new Date(
+    currentDate.getFullYear(),
+    currentDate.getMonth() + 1,
+    0,
+  ).getDate(),
+});
+
+// ==================== 커스텀 훅 ====================
+const useDayCounter = () => {
+  const [days, setDays] = useState(0);
+
+  useEffect(() => {
+    const totalDays = calculateDaysDiff(START_DATE, new Date());
+    const increment = totalDays / ANIMATION_CONFIG.duration;
+
+    let current = 0;
+    const timer = setInterval(() => {
+      current += increment;
+      if (current >= totalDays) {
+        setDays(totalDays);
+        clearInterval(timer);
+      } else {
+        setDays(Math.floor(current));
+      }
+    }, ANIMATION_CONFIG.interval);
+
+    return () => clearInterval(timer);
+  }, []);
+
+  return days;
+};
+
+const useGitHubPosts = () => {
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setLoading(false);
+    }, ANIMATION_CONFIG.loadingDelay);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return { loading };
+};
+
+// ==================== 컴포넌트 ====================
+function SectionHeader() {
+  return (
+    <div className="flex items-center space-x-2">
+      <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
+      <h2 className="text-lg font-light text-blue-300 tracking-wider">
+        ACTIVITY
+      </h2>
+    </div>
+  );
+}
+
+function DayCounter() {
+  const days = useDayCounter();
+
+  return (
+    <div className="bg-gray-900/50 backdrop-blur-lg border border-blue-500/20 rounded-lg p-4 text-center">
+      <div className="flex items-center justify-center space-x-2 mb-2">
+        <div className="w-2 h-2 bg-green-400 rounded-full animate-pulse" />
+        <span className="text-xs text-gray-400 uppercase tracking-wider">
+          EDITH 학습한지
+        </span>
+      </div>
+      <div className="text-3xl font-bold text-green-400 font-mono">
+        D+{days}
+      </div>
+    </div>
+  );
+}
+
+function CalendarNavigation({
+  year,
+  month,
+  onPrevMonth,
+  onNextMonth,
+}: {
+  year: number;
+  month: number;
+  onPrevMonth: () => void;
+  onNextMonth: () => void;
+}) {
+  return (
+    <div className="flex items-center justify-between mb-3">
+      <h3 className="text-sm font-medium text-blue-300">
+        {year}년 {MONTH_NAMES[month]}
+      </h3>
+      <div className="flex space-x-1">
+        <button
+          onClick={onPrevMonth}
+          className="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-white transition-colors"
+        >
+          ←
+        </button>
+        <button
+          onClick={onNextMonth}
+          className="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-white transition-colors"
+        >
+          →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CalendarGrid({ calendarData }: { calendarData: CalendarDate }) {
+  const { firstDay, lastDate, today } = calendarData;
+
+  const renderDays = () => {
+    const days = [];
+
+    // 빈 칸들
+    for (let i = 0; i < firstDay; i++) {
+      days.push(<div key={`empty-${i}`} className="w-8 h-8" />);
+    }
+
+    // 날짜들
+    for (let date = 1; date <= lastDate; date++) {
+      const isToday = date === today;
+
+      days.push(
+        <div
+          key={date}
+          className={`
+            w-8 h-8 flex items-center justify-center text-xs rounded transition-all cursor-pointer
+            ${
+              isToday
+                ? "bg-blue-500 text-white font-bold"
+                : "text-gray-500 hover:text-gray-300"
+            }
+          `}
+        >
+          {date}
+        </div>,
+      );
+    }
+
+    return days;
+  };
+
+  return (
+    <>
+      {/* 요일 헤더 */}
+      <div className="grid grid-cols-7 gap-1 mb-2">
+        {WEEK_DAYS.map((day) => (
+          <div
+            key={day}
+            className="text-xs text-gray-400 text-center font-medium"
+          >
+            {day}
+          </div>
+        ))}
+      </div>
+
+      {/* 날짜 그리드 */}
+      <div className="grid grid-cols-7 gap-1">{renderDays()}</div>
+    </>
+  );
+}
+
+function MiniCalendar() {
+  const [currentDate, setCurrentDate] = useState(new Date());
+  const calendarData = getCalendarData(currentDate);
+
+  const handlePrevMonth = () => {
+    setCurrentDate(new Date(calendarData.year, calendarData.month - 1));
+  };
+
+  const handleNextMonth = () => {
+    setCurrentDate(new Date(calendarData.year, calendarData.month + 1));
+  };
+
+  return (
+    <div className="bg-gray-900/50 backdrop-blur-lg border border-blue-500/20 rounded-lg p-4">
+      <CalendarNavigation
+        year={calendarData.year}
+        month={calendarData.month}
+        onPrevMonth={handlePrevMonth}
+        onNextMonth={handleNextMonth}
+      />
+
+      <CalendarGrid calendarData={calendarData} />
+
+      {/* 범례 */}
+      <div className="flex items-center justify-center mt-3 text-xs">
+        <div className="flex items-center space-x-1">
+          <div className="w-2 h-2 bg-blue-500 rounded" />
+          <span className="text-gray-400">오늘</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 3 }, (_, i) => (
+        <div key={i} className="animate-pulse">
+          <div className="h-4 bg-gray-700 rounded w-3/4 mb-2" />
+          <div className="h-3 bg-gray-800 rounded w-1/2" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="text-center py-8 text-gray-500">
+      <div className="text-2xl mb-2">📄</div>
+      <div className="text-sm">GitHub 연동 준비 중</div>
+      <div className="text-xs text-gray-600 mt-1">API 연결이 필요합니다</div>
+    </div>
+  );
+}
+
+function GitHubPosts() {
+  const { loading } = useGitHubPosts();
+
+  return (
+    <div className="bg-gray-900/50 backdrop-blur-lg border border-blue-500/20 rounded-lg p-4">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-medium text-blue-300">GitHub Posts</h3>
+        <span className="text-xs text-gray-400">edith-docs</span>
+      </div>
+
+      {loading ? <LoadingSkeleton /> : <EmptyState />}
+    </div>
+  );
+}
+
+// ==================== 메인 컴포넌트 ====================
+export default function ActivityList() {
+  return (
+    <div className="space-y-4">
+      <SectionHeader />
+      <DayCounter />
+      <MiniCalendar />
+      <GitHubPosts />
+    </div>
+  );
+}

--- a/src/components/dashboard/StatusBar.tsx
+++ b/src/components/dashboard/StatusBar.tsx
@@ -1,0 +1,154 @@
+// src/components/dashboard/StatusBar.tsx
+"use client";
+
+import { useState, useEffect } from "react";
+
+// ==================== 타입 정의 ====================
+interface StatusCardProps {
+  icon: string;
+  title: string;
+  value: number;
+  subtitle: string;
+  color: string;
+}
+
+interface StatData {
+  posts: number;
+  visitors: number;
+  commits: number;
+}
+
+// ==================== 상수 ====================
+const MOCK_DATA: StatData = {
+  posts: 42,
+  visitors: 1247,
+  commits: 156,
+};
+
+const ANIMATION_CONFIG = {
+  duration: 2000,
+  interval: 50,
+} as const;
+
+// ==================== 유틸리티 함수 ====================
+const getStatusColor = (isOnline: boolean): string =>
+  isOnline ? "bg-green-500/20" : "bg-red-500/20";
+
+const getStatusText = (isOnline: boolean): string =>
+  isOnline ? "online" : "offline";
+
+// ==================== 컴포넌트 ====================
+function AnimatedCounter({ target }: { target: number }) {
+  const [count, setCount] = useState(0);
+
+  useEffect(() => {
+    const increment =
+      target / (ANIMATION_CONFIG.duration / ANIMATION_CONFIG.interval);
+
+    const timer = setInterval(() => {
+      setCount((prev) => {
+        const next = prev + increment;
+        if (next >= target) {
+          clearInterval(timer);
+          return target;
+        }
+        return next;
+      });
+    }, ANIMATION_CONFIG.interval);
+
+    return () => clearInterval(timer);
+  }, [target]);
+
+  return Math.floor(count);
+}
+
+function StatusCard({ icon, title, value, subtitle, color }: StatusCardProps) {
+  return (
+    <div className="bg-gray-900/50 backdrop-blur-lg border border-blue-500/20 rounded-lg p-4 hover:border-blue-400/40 transition-all duration-200 group">
+      <div className="flex items-center space-x-3">
+        <div
+          className={`w-10 h-10 ${color} rounded-lg flex items-center justify-center group-hover:scale-105 transition-transform`}
+        >
+          <span className="text-xl">{icon}</span>
+        </div>
+        <div className="flex-1">
+          <div className="text-xs text-gray-400 uppercase tracking-wide">
+            {title}
+          </div>
+          <div className="text-2xl font-bold text-white">
+            <AnimatedCounter target={value} />
+          </div>
+          <div className="text-xs text-gray-500">{subtitle}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SectionHeader() {
+  return (
+    <div className="flex items-center space-x-2">
+      <div className="w-2 h-2 bg-blue-400 rounded-full animate-pulse" />
+      <h2 className="text-lg font-light text-blue-300 tracking-wider">
+        SYSTEM STATUS
+      </h2>
+    </div>
+  );
+}
+
+function useGitHubStatus() {
+  const [isOnline, setIsOnline] = useState(true);
+
+  useEffect(() => {
+    const checkStatus = () => {
+      setIsOnline(Math.random() > 0.1); // 90% 확률로 온라인
+    };
+
+    checkStatus();
+    const interval = setInterval(checkStatus, 30000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  return isOnline;
+}
+
+// ==================== 메인 컴포넌트 ====================
+export default function StatusBar() {
+  const isGitHubOnline = useGitHubStatus();
+
+  const statusCards = [
+    {
+      icon: "📝",
+      title: "Total Posts",
+      value: MOCK_DATA.posts,
+      subtitle: "published articles",
+      color: "bg-blue-500/20",
+    },
+    {
+      icon: "👥",
+      title: "Visitors",
+      value: MOCK_DATA.visitors,
+      subtitle: "this month",
+      color: "bg-green-500/20",
+    },
+    {
+      icon: "📊",
+      title: "GitHub",
+      value: MOCK_DATA.commits,
+      subtitle: `commits • ${getStatusText(isGitHubOnline)}`,
+      color: getStatusColor(isGitHubOnline),
+    },
+  ];
+
+  return (
+    <div className="space-y-4">
+      <SectionHeader />
+      <div className="space-y-3">
+        {statusCards.map((card, index) => (
+          <StatusCard key={index} {...card} />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 🎯 Overview
E.D.I.T.H 메인 대시보드 구현

## ✨ Features
- **StatusBar**: 시스템 상태 모니터링 (포스트 수, 방문자, GitHub)
- **AIPanel**: AI 어시스턴트 소개 (개발 중 상태 표시)
- **ActivityList**: D+ 카운터, 캘린더, GitHub 연동 준비

## 🎨 Design
- 3열 반응형 레이아웃 (모바일: 세로 스택, 데스크톱: 3열)
- E.D.I.T.H 홀로그램 스타일 (파란색 네온 테마)
- 애니메이션 카운터 및 호버 효과

## 🛠️ Technical Details
- **TypeScript** 완전 타입 안정성
- **Tailwind CSS** 반응형 디자인
- **컴포넌트 분리** 및 재사용성
- **커스텀 훅** (useGitHubStatus, useDayCounter, useGitHubPosts)

## 📱 Responsive
- **모바일**: 세로 스택 레이아웃
- **데스크톱**: 3열 완전 레이아웃

## ✅ Acceptance Criteria
- [x] 왼쪽 상태바 (포스트 수, 방문자 수, 시스템 상태)
- [x] 중앙 AI 설명 패널 (개발 중 상태)
- [x] 오른쪽 리스트 (D+카운터, 캘린더, GitHub 준비)
- [x] 반응형 디자인 (모바일: 세로, 데스크톱: 3열)
- [x] E.D.I.T.H 홀로그램 스타일 UI/UX
- [x] 애니메이션 효과

## 🔮 Future Tasks
- GitHub API 연동으로 실제 데이터 표시
- AI 기능 구현
- 태블릿 반응형 최적화

Closes #8